### PR TITLE
improved touch slider wizard

### DIFF
--- a/touch_slider_wizard.py
+++ b/touch_slider_wizard.py
@@ -25,28 +25,28 @@ from pcbnew import *
 import FootprintWizardBase
 import pcbnew
 
-class TouchSliderWizard(FootprintWizardBase.FootprintWizard):
 
+class TouchSliderWizard(FootprintWizardBase.FootprintWizard):
     def GetName(self):
         """
         Return footprint name.
         This is specific to each footprint class, you need to implement this
         """
-        return 'Touch Slider'
+        return "Touch Slider"
 
     def GetDescription(self):
         """
         Return footprint description.
         This is specific to each footprint class, you need to implement this
         """
-        return 'Capacitive Touch Slider wizard'
+        return "Capacitive Touch Slider wizard"
 
     def GetValue(self):
         return "TouchSlider-{s}_{x:g}x{y:g}mm".format(
-            s = self.pads['steps'],
-            x = pcbnew.ToMM(self.pads['length']),
-            y = pcbnew.ToMM(self.pads['width'])
-            )
+            s=self.pads["steps"],
+            x=pcbnew.ToMM(self.pads["length"]),
+            y=pcbnew.ToMM(self.pads["width"]),
+        )
 
     def GenerateParameterList(self):
         self.AddParam("Pads", "steps", self.uInteger, 4, min_value=2)
@@ -59,10 +59,10 @@ class TouchSliderWizard(FootprintWizardBase.FootprintWizard):
 
     @property
     def pads(self):
-        return self.parameters['Pads']
+        return self.parameters["Pads"]
 
     # build a rectangular pad
-    def smdRectPad(self,module,size,pos,name):
+    def smdRectPad(self, module, size, pos, name):
         pad = D_PAD(module)
         pad.SetSize(size)
         pad.SetShape(PAD_SHAPE_RECT)
@@ -70,174 +70,202 @@ class TouchSliderWizard(FootprintWizardBase.FootprintWizard):
 
         layerset = pcbnew.LSET()
         layerset.AddLayer(currentLayer)
-        #layerset.AddLayer(pcbnew.F_Mask)
-        pad.SetLayerSet( layerset )
+        pad.SetLayerSet(layerset)
 
         pad.SetPos0(pos)
         pad.SetPosition(pos)
         pad.SetName(name)
         return pad
 
-
-    def smdTrianglePad(self,module,size,pos,name,up_down=1,left_right=0):
+    def smdTrianglePad(self, module, size, pos, name, up_down=1, left_right=0):
         pad = D_PAD(module)
-        pad.SetSize(wxSize(size[0],size[1]))
+        pad.SetSize(wxSize(size[0], size[1]))
         pad.SetShape(PAD_SHAPE_TRAPEZOID)
         pad.SetAttribute(PAD_ATTRIB_SMD)
 
         layerset = pcbnew.LSET()
         layerset.AddLayer(currentLayer)
-        #layerset.AddLayer(pcbnew.F_Mask)
-        pad.SetLayerSet( layerset )
+        pad.SetLayerSet(layerset)
 
         pad.SetPos0(pos)
         pad.SetPosition(pos)
         pad.SetName(name)
-        pad.SetDelta(wxSize(left_right*size[1],up_down*size[0]))
+        pad.SetDelta(wxSize(left_right * size[1], up_down * size[0]))
         return pad
-
 
     # This method checks the parameters provided to wizard and set errors
     def CheckParameters(self):
-        #TODO - implement custom checks
+        # TODO - implement custom checks
         pass
 
     # The start pad is made of a rectangular pad plus a couple of
     # triangular pads facing tips on the middle/right of the first
     # rectangular pad
-    def AddStartPad(self,position,touch_width,step_length,clearance,name):
+    def AddStartPad(self, position, touch_width, step_length, clearance, name):
         module = self.module
         step_length = step_length - clearance
-        size_pad = wxSize(step_length/2.0+(step_length/3),touch_width)
-        pad = self.smdRectPad(module,size_pad,position-wxPoint(step_length/6,0),name)
+        size_pad = wxSize(step_length / 2.0 + (step_length / 3), touch_width)
+        pad = self.smdRectPad(
+            module, size_pad, position - wxPoint(step_length / 6, 0), name
+        )
         module.Add(pad)
 
-        size_pad = wxSize(step_length/2.0,touch_width)
+        size_pad = wxSize(step_length / 2.0, touch_width)
 
-        tp = self.smdTrianglePad(module,wxSize(size_pad[0],size_pad[1]/2),
-                                 position+wxPoint(size_pad[0]/2,size_pad[1]/4),
-                                name)
+        tp = self.smdTrianglePad(
+            module,
+            wxSize(size_pad[0], size_pad[1] / 2),
+            position + wxPoint(size_pad[0] / 2, size_pad[1] / 4),
+            name,
+        )
         module.Add(tp)
-        tp = self.smdTrianglePad(module,wxSize(size_pad[0],size_pad[1]/2),
-                                 position+wxPoint(size_pad[0]/2,-size_pad[1]/4),
-                                name
-                                ,-1)
+        tp = self.smdTrianglePad(
+            module,
+            wxSize(size_pad[0], size_pad[1] / 2),
+            position + wxPoint(size_pad[0] / 2, -size_pad[1] / 4),
+            name,
+            -1,
+        )
         module.Add(tp)
 
     # compound a "start pad" shape plus a triangle on the left, pointing to
     # the previous touch-pad
-    def AddMiddlePad(self,position,touch_width,step_length,clearance,name):
+    def AddMiddlePad(self, position, touch_width, step_length, clearance, name):
         module = self.module
         step_length = step_length - clearance
-        size_pad = wxSize(step_length/2.0,touch_width)
+        size_pad = wxSize(step_length / 2.0, touch_width)
 
-        size_pad = wxSize(step_length/2.0,touch_width)
-        pad = self.smdRectPad(module,size_pad,position,name)
+        size_pad = wxSize(step_length / 2.0, touch_width)
+        pad = self.smdRectPad(module, size_pad, position, name)
         module.Add(pad)
 
-        tp = self.smdTrianglePad(module,wxSize(size_pad[0],size_pad[1]/2),
-                                 position+wxPoint(size_pad[0]/2,size_pad[1]/4),
-                                name)
+        tp = self.smdTrianglePad(
+            module,
+            wxSize(size_pad[0], size_pad[1] / 2),
+            position + wxPoint(size_pad[0] / 2, size_pad[1] / 4),
+            name,
+        )
         module.Add(tp)
-        tp = self.smdTrianglePad(module,wxSize(size_pad[0],size_pad[1]/2),
-                                 position+wxPoint(size_pad[0]/2,-size_pad[1]/4),
-                                name
-                                ,-1)
+        tp = self.smdTrianglePad(
+            module,
+            wxSize(size_pad[0], size_pad[1] / 2),
+            position + wxPoint(size_pad[0] / 2, -size_pad[1] / 4),
+            name,
+            -1,
+        )
         module.Add(tp)
 
-        tp = self.smdTrianglePad(module,wxSize(size_pad[0],size_pad[1]/2),
-                                        position+wxPoint(-size_pad[0],0),
-                                        name,
-                                        0,
-                                        -1)
+        tp = self.smdTrianglePad(
+            module,
+            wxSize(size_pad[0], size_pad[1] / 2),
+            position + wxPoint(-size_pad[0], 0),
+            name,
+            0,
+            -1,
+        )
         module.Add(tp)
 
-
-    def AddFinalPad(self,position,touch_width,step_length,clearance,name):
+    def AddFinalPad(self, position, touch_width, step_length, clearance, name):
         module = self.module
         step_length = step_length - clearance
-        size_pad = wxSize(step_length/2.0,touch_width)
+        size_pad = wxSize(step_length / 2.0, touch_width)
 
-        pad = self.smdRectPad(module,
-                              wxSize(size_pad[0]+(step_length/3),size_pad[1]),
-                              position+wxPoint(step_length/6,0),
-                              name)
+        pad = self.smdRectPad(
+            module,
+            wxSize(size_pad[0] + (step_length / 3), size_pad[1]),
+            position + wxPoint(step_length / 6, 0),
+            name,
+        )
         module.Add(pad)
 
-        tp = self.smdTrianglePad(module,wxSize(size_pad[0],size_pad[1]/2),
-                                        position+wxPoint(-size_pad[0],0),
-                                        name,
-                                        0,
-                                        -1)
+        tp = self.smdTrianglePad(
+            module,
+            wxSize(size_pad[0], size_pad[1] / 2),
+            position + wxPoint(-size_pad[0], 0),
+            name,
+            0,
+            -1,
+        )
         module.Add(tp)
 
-    def AddStrip(self,pos,steps,touch_width,step_length,touch_clearance):
-        self.AddStartPad(pos,touch_width,step_length,touch_clearance,"1")
+    def AddStrip(self, pos, steps, touch_width, step_length, touch_clearance):
+        self.AddStartPad(pos, touch_width, step_length, touch_clearance, "1")
 
-        for n in range(2,steps):
-            pos = pos + wxPoint(step_length,0)
-            self.AddMiddlePad(pos,touch_width,step_length,touch_clearance,str(n))
+        for n in range(2, steps):
+            pos = pos + wxPoint(step_length, 0)
+            self.AddMiddlePad(pos, touch_width, step_length, touch_clearance, str(n))
 
-        pos = pos + wxPoint(step_length,0)
-        self.AddFinalPad(pos,touch_width,step_length,touch_clearance,str(steps))
+        pos = pos + wxPoint(step_length, 0)
+        self.AddFinalPad(pos, touch_width, step_length, touch_clearance, str(steps))
 
-    def AddYElectrodes(self,touch_length,touch_width,y_width,electrodeName):
-        yElectrodeSpacing   = 4
-        yElectrodeCount     = (int)(((pcbnew.ToMM(touch_width)-4)/yElectrodeSpacing))+1
+    def AddYElectrodes(self, touch_length, touch_width, y_width, electrodeName):
+        yElectrodeSpacing = 4
+        yElectrodeCount = (int)(
+            ((pcbnew.ToMM(touch_width) - 4) / yElectrodeSpacing)
+        ) + 1
         yElectrodeThickness = y_width
 
-        currentLayer  = pcbnew.F_Cu
-        yPosition     = (pcbnew.ToMM(touch_width)/2)-((pcbnew.ToMM(touch_width)-((yElectrodeCount-1)*yElectrodeSpacing))/2.0)
+        currentLayer = pcbnew.F_Cu
+        yPosition = (pcbnew.ToMM(touch_width) / 2) - (
+            (pcbnew.ToMM(touch_width) - ((yElectrodeCount - 1) * yElectrodeSpacing))
+            / 2.0
+        )
 
-        for i in range(0,yElectrodeCount):
+        for i in range(0, yElectrodeCount):
             pad = self.smdRectPad(
                 self.module,
-                wxSize(touch_length,yElectrodeThickness),
-                wxPoint(0,pcbnew.FromMM(yPosition)),
-                str(electrodeName))
+                wxSize(touch_length, yElectrodeThickness),
+                wxPoint(0, pcbnew.FromMM(yPosition)),
+                str(electrodeName),
+            )
             self.module.Add(pad)
             yPosition -= yElectrodeSpacing
 
-        #Leftmost line that connects all electrodes
+        # Leftmost line that connects all electrodes
         pad = self.smdRectPad(
             self.module,
-            wxSize(yElectrodeThickness,(yElectrodeCount-1)*pcbnew.FromMM(yElectrodeSpacing)+yElectrodeThickness),
-            wxPoint(-touch_length/2,0),
-            str(electrodeName))
+            wxSize(
+                yElectrodeThickness,
+                (yElectrodeCount - 1) * pcbnew.FromMM(yElectrodeSpacing)
+                + yElectrodeThickness,
+            ),
+            wxPoint(-touch_length / 2, 0),
+            str(electrodeName),
+        )
         self.module.Add(pad)
 
     # build the footprint from parameters
     # FIX ME: the X and Y position of the footprint can be better.
     def BuildThisFootprint(self):
 
-        steps             = self.pads["steps"]
-        bands             = self.pads["bands"]
-        touch_width       = self.pads["width"]
-        touch_length      = self.pads["length"]
-        touch_clearance   = self.pads["clearance"]
-        split_electrodes  = self.pads["split electrodes"]
-        y_width           = self.pads["y-width"]
+        steps = self.pads["steps"]
+        bands = self.pads["bands"]
+        touch_width = self.pads["width"]
+        touch_length = self.pads["length"]
+        touch_clearance = self.pads["clearance"]
+        split_electrodes = self.pads["split electrodes"]
+        y_width = self.pads["y-width"]
 
         step_length = float(touch_length) / float(steps)
 
         global currentLayer
-        if(split_electrodes):
+        if split_electrodes:
             currentLayer = pcbnew.B_Cu
         else:
             currentLayer = pcbnew.F_Cu
 
         t_size = self.GetTextSize()
         w_text = self.draw.GetLineThickness()
-        ypos = touch_width/2 + t_size/2 + w_text
+        ypos = touch_width / 2 + t_size / 2 + w_text
         self.draw.Value(0, -ypos, t_size)
-        ypos += t_size + w_text*2
+        ypos += t_size + w_text * 2
         self.draw.Reference(0, -ypos, t_size)
 
         # set SMD attribute
         self.module.SetAttributes(MOD_CMS)
 
         # starting pad
-        band_width = touch_width/bands
+        band_width = touch_width / bands
 
         xpos = -0.5 * (steps - 1) * step_length
         ypos = -0.5 * (bands - 1) * band_width
@@ -245,12 +273,12 @@ class TouchSliderWizard(FootprintWizardBase.FootprintWizard):
         pos = wxPointMM(pcbnew.ToMM(xpos), pcbnew.ToMM(ypos))
 
         for b in range(bands):
-            self.AddStrip(pos,steps,band_width,step_length,touch_clearance)
-            pos += wxPoint(0,band_width)
+            self.AddStrip(pos, steps, band_width, step_length, touch_clearance)
+            pos += wxPoint(0, band_width)
 
-        if(split_electrodes):
+        if split_electrodes:
             currentLayer = pcbnew.F_Cu
-            self.AddYElectrodes(touch_length,touch_width,y_width,steps+1)
+            self.AddYElectrodes(touch_length, touch_width, y_width, steps + 1)
+
 
 TouchSliderWizard().register()
-

--- a/touch_slider_wizard.py
+++ b/touch_slider_wizard.py
@@ -200,9 +200,7 @@ class TouchSliderWizard(FootprintWizardBase.FootprintWizard):
 
     def AddYElectrodes(self, touch_length, touch_width, y_width, electrodeName):
         yElectrodeSpacing = 4
-        yElectrodeCount = (int)(
-            ((pcbnew.ToMM(touch_width) - 4) / yElectrodeSpacing)
-        ) + 1
+        yElectrodeCount = int(((pcbnew.ToMM(touch_width) - 4) / yElectrodeSpacing)) + 1
         yElectrodeThickness = y_width
 
         currentLayer = pcbnew.F_Cu

--- a/touch_slider_wizard.py
+++ b/touch_slider_wizard.py
@@ -54,6 +54,8 @@ class TouchSliderWizard(FootprintWizardBase.FootprintWizard):
         self.AddParam("Pads", "width", self.uMM, 10)
         self.AddParam("Pads", "length", self.uMM, 50)
         self.AddParam("Pads", "clearance", self.uMM, 1)
+        self.AddParam("Pads", "split electrodes", self.uBool, 0)
+        self.AddParam("Pads", "y-width", self.uMM, 0.1)
 
     @property
     def pads(self):
@@ -65,7 +67,12 @@ class TouchSliderWizard(FootprintWizardBase.FootprintWizard):
         pad.SetSize(size)
         pad.SetShape(PAD_SHAPE_RECT)
         pad.SetAttribute(PAD_ATTRIB_SMD)
-        pad.SetLayerSet(pad.ConnSMDMask())
+
+        layerset = pcbnew.LSET()
+        layerset.AddLayer(currentLayer)
+        #layerset.AddLayer(pcbnew.F_Mask)
+        pad.SetLayerSet( layerset )
+
         pad.SetPos0(pos)
         pad.SetPosition(pos)
         pad.SetName(name)
@@ -77,7 +84,12 @@ class TouchSliderWizard(FootprintWizardBase.FootprintWizard):
         pad.SetSize(wxSize(size[0],size[1]))
         pad.SetShape(PAD_SHAPE_TRAPEZOID)
         pad.SetAttribute(PAD_ATTRIB_SMD)
-        pad.SetLayerSet(pad.ConnSMDMask())
+
+        layerset = pcbnew.LSET()
+        layerset.AddLayer(currentLayer)
+        #layerset.AddLayer(pcbnew.F_Mask)
+        pad.SetLayerSet( layerset )
+
         pad.SetPos0(pos)
         pad.SetPosition(pos)
         pad.SetName(name)
@@ -169,6 +181,31 @@ class TouchSliderWizard(FootprintWizardBase.FootprintWizard):
         pos = pos + wxPoint(step_length,0)
         self.AddFinalPad(pos,touch_width,step_length,touch_clearance,str(steps))
 
+    def AddYElectrodes(self,touch_length,touch_width,y_width,electrodeName):
+        yElectrodeSpacing   = 4
+        yElectrodeCount     = (int)(((pcbnew.ToMM(touch_width)-4)/yElectrodeSpacing))+1
+        yElectrodeThickness = y_width
+
+        currentLayer  = pcbnew.F_Cu
+        yPosition     = (pcbnew.ToMM(touch_width)/2)-((pcbnew.ToMM(touch_width)-((yElectrodeCount-1)*yElectrodeSpacing))/2.0)
+
+        for i in range(0,yElectrodeCount):
+            pad = self.smdRectPad(
+                self.module,
+                wxSize(touch_length,yElectrodeThickness),
+                wxPoint(0,pcbnew.FromMM(yPosition)),
+                str(electrodeName))
+            self.module.Add(pad)
+            yPosition -= yElectrodeSpacing
+
+        #Leftmost line that connects all electrodes
+        pad = self.smdRectPad(
+            self.module,
+            wxSize(yElectrodeThickness,(yElectrodeCount-1)*pcbnew.FromMM(yElectrodeSpacing)+yElectrodeThickness),
+            wxPoint(-touch_length/2,0),
+            str(electrodeName))
+        self.module.Add(pad)
+
     # build the footprint from parameters
     # FIX ME: the X and Y position of the footprint can be better.
     def BuildThisFootprint(self):
@@ -178,8 +215,16 @@ class TouchSliderWizard(FootprintWizardBase.FootprintWizard):
         touch_width       = self.pads["width"]
         touch_length      = self.pads["length"]
         touch_clearance   = self.pads["clearance"]
+        split_electrodes  = self.pads["split electrodes"]
+        y_width           = self.pads["y-width"]
 
         step_length = float(touch_length) / float(steps)
+
+        global currentLayer
+        if(split_electrodes):
+            currentLayer = pcbnew.B_Cu
+        else:
+            currentLayer = pcbnew.F_Cu
 
         t_size = self.GetTextSize()
         w_text = self.draw.GetLineThickness()
@@ -202,6 +247,10 @@ class TouchSliderWizard(FootprintWizardBase.FootprintWizard):
         for b in range(bands):
             self.AddStrip(pos,steps,band_width,step_length,touch_clearance)
             pos += wxPoint(0,band_width)
+
+        if(split_electrodes):
+            currentLayer = pcbnew.F_Cu
+            self.AddYElectrodes(touch_length,touch_width,y_width,steps+1)
 
 TouchSliderWizard().register()
 


### PR DESCRIPTION
Improved the capacitive slider wizard.
You can now either select "normal mode" (self capacitance,the one you had before) or you can chose to split electrodes the electrodes (for mutual capacitance sliders with flooded x-electrode)
Measurements are taken from [QTAN0079](http://ww1.microchip.com/downloads/en/appnotes/doc10752.pdf), Page 62.

Minimal 2mm Distance from the Edge, 4mm between electrodes.

------------

Thanks for creating a pull request to contribute to the KiCad footprint wizards! To speed up integration of your PR, please check the following items:

- [x] Provide a description for your PR (are you creating a new wizard or improving an existing one?)
- [x] Include a screenshot of the wizard screen with an example created footprint

![grafik](https://user-images.githubusercontent.com/50383630/67695468-6c18de80-f9a5-11e9-96a3-6b9fc8ad45e4.png)

![grafik](https://user-images.githubusercontent.com/50383630/67695484-733fec80-f9a5-11e9-9fd4-89fabea7e562.png)
