### PR TITLE
add mutual capacitance button wizard

### DIFF
--- a/mutualcap_button_wizard.py
+++ b/mutualcap_button_wizard.py
@@ -1,0 +1,117 @@
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+
+import FootprintWizardBase
+import pcbnew
+from pcbnew import *
+
+class MutualcapButtonWizard(FootprintWizardBase.FootprintWizard):
+
+    def GetName(self):
+        """
+        Return footprint name.
+        This is specific to each footprint class, you need to implement this
+        """
+        return "Mutualcap Touch Button"
+
+    def GetDescription(self):
+        """
+        Return footprint description.
+        This is specific to each footprint class, you need to implement this
+        """
+        return "Wizard for Mutual Capacitance Touch Buttons."
+
+    def GetValue(self):
+        return "TouchButton-{width:g}x{height:g}mm".format(
+            width = pcbnew.ToMM(self.pads["Width"]),
+            height= pcbnew.ToMM(self.pads["Height"])
+            )
+
+    def GenerateParameterList(self):
+        #self.AddParam("Pads", "panel_thickness",self.uMM)
+        self.AddParam("Pads", "T (Panel thickness)", self.uMM, 1.6)
+        self.AddParam("Pads", "Width", self.uMM, 12)
+        self.AddParam("Pads", "Height", self.uMM, 12)
+        self.AddParam("Pads", "Y width", self.uMM, 0.1)
+
+
+    @property
+    def pads(self):
+        return self.parameters["Pads"]
+
+
+    # build a rectangular pad
+    def smdRectPad(self,module,size,pos,name):
+        pad = D_PAD(module)
+        pad.SetSize(size)
+        pad.SetShape(PAD_SHAPE_RECT)
+        pad.SetAttribute(PAD_ATTRIB_SMD)
+
+        layerset = pcbnew.LSET()
+        layerset.AddLayer(currentLayer)
+        pad.SetLayerSet(layerset)
+
+        pad.SetPos0(pos)
+        pad.SetPosition(pos)
+        pad.SetName(name)
+        return pad
+
+    # This method checks the parameters provided to wizard and set errors
+    def CheckParameters(self):
+        pass
+
+    def BuildThisFootprint(self):
+        t  = self.pads["T (Panel thickness)"]
+        w  = self.pads["Width"]
+        h  = self.pads["Height"]
+        yw = self.pads["Y width"]
+
+        xFingers     = int((w-3*t-yw)/(1.5*t+yw))
+        xBorderWidth = (w-t-yw-xFingers*(1.5*t+yw))/2
+        clearance    = t/2
+
+        ###border h
+        self.module.SetLayer(F_Cu)
+        size_pad = pcbnew.wxSize( w, t )
+        self.module.Add(self.smdRectPad(self.module,size_pad, pcbnew.wxPoint(0,(-h/2)+t/2),str(1)))
+        self.module.Add(self.smdRectPad(self.module,size_pad, pcbnew.wxPoint(0,( h/2)-t/2),str(1)))
+        ###border v
+        size_pad = pcbnew.wxSize(xBorderWidth, h-2*t)
+        self.module.Add(self.smdRectPad(self.module,size_pad, pcbnew.wxPoint((-w/2)+xBorderWidth/2,0),str(1)))
+        self.module.Add(self.smdRectPad(self.module,size_pad, pcbnew.wxPoint(( w/2)-xBorderWidth/2,0),str(1)))
+
+        xPos = -w/2+xBorderWidth+clearance+yw
+        xFingerSize = pcbnew.wxSize(t/2, h-t-yw-2*clearance-t)
+        yFingerSize = pcbnew.wxSize(yw,h-2*t-2*clearance)
+        #horizontal y-trace
+        self.module.Add(self.smdRectPad(self.module,pcbnew.wxSize(w-2*xBorderWidth-2*clearance,yw), pcbnew.wxPoint(0,h/2-t-clearance-yw/2),str(2)))
+        for i in range(0,xFingers):
+            #y-fingers
+            self.module.Add(self.smdRectPad(self.module,yFingerSize, pcbnew.wxPoint(xPos-yw/2 ,0),str(2)))
+            #x-fingers
+            self.module.Add(self.smdRectPad(self.module,xFingerSize, pcbnew.wxPoint(xPos+t*0.75,-w/h-t-yw/2+t/2),str(1)))
+            xPos += t*1.5+yw
+
+        #rightmost y-finger
+        self.module.Add(self.smdRectPad(self.module,yFingerSize, pcbnew.wxPoint(xPos-yw/2,0),str(2)))
+
+        textSize = self.GetTextSize()
+        self.draw.Value(0, h/2+textSize, textSize)
+        self.draw.Reference(0, -h/2-textSize, textSize)
+        
+        
+
+MutualcapButtonWizard().register()

--- a/mutualcap_button_wizard.py
+++ b/mutualcap_button_wizard.py
@@ -42,9 +42,9 @@ class MutualcapButtonWizard(FootprintWizardBase.FootprintWizard):
             )
 
     def GenerateParameterList(self):
-        self.AddParam("Pads", "Panel thickness", self.uMM, 1.6)
         self.AddParam("Pads", "Width", self.uMM, 12)
         self.AddParam("Pads", "Height", self.uMM, 12)
+        self.AddParam("Pads", "Outer electrode width", self.uMM, 1)
         self.AddParam("Pads", "Inner electrode width", self.uMM, 0.1)
         self.AddParam("Pads", "Draw line around button", self.uBool, True)
 
@@ -76,39 +76,39 @@ class MutualcapButtonWizard(FootprintWizardBase.FootprintWizard):
     def BuildThisFootprint(self):
         # o refers to the outer (drive) electrode
         # i refers to the inner (receive) electrode
-        pt  = self.pads["Panel thickness"]
-        w  = self.pads["Width"]
-        h  = self.pads["Height"]
+        w   = self.pads["Width"]
+        h   = self.pads["Height"]
+        oew = self.pads["Outer electrode width"]
         iew = self.pads["Inner electrode width"]
         drawBox = self.pads["Draw line around button"]
 
-        oFingerCount = int((w-3*pt-iew)/(1.5*pt+iew))
-        oBorderWidth = (w-pt-iew-oFingerCount*(1.5*pt+iew))/2
-        clearance     = pt/2
+        oFingerCount = int((w-3*oew-iew)/(1.5*oew+iew))
+        oBorderWidth = (w-oew-iew-oFingerCount*(1.5*oew+iew))/2
+        clearance    = oew/2
 
         ###border h
         self.module.SetLayer(F_Cu)
-        size_pad = pcbnew.wxSize( w, pt )
-        self.module.Add(self.smdRectPad(self.module,size_pad, pcbnew.wxPoint(0,(-h/2)+pt/2),str(1)))
-        self.module.Add(self.smdRectPad(self.module,size_pad, pcbnew.wxPoint(0,( h/2)-pt/2),str(1)))
+        size_pad = pcbnew.wxSize( w, oew )
+        self.module.Add(self.smdRectPad(self.module,size_pad, pcbnew.wxPoint(0,(-h/2)+oew/2),str(1)))
+        self.module.Add(self.smdRectPad(self.module,size_pad, pcbnew.wxPoint(0,( h/2)-oew/2),str(1)))
         ###border v
-        size_pad = pcbnew.wxSize(oBorderWidth, h-2*pt)
+        size_pad = pcbnew.wxSize(oBorderWidth, h-2*oew)
         self.module.Add(self.smdRectPad(self.module,size_pad, pcbnew.wxPoint((-w/2)+oBorderWidth/2,0),str(1)))
         self.module.Add(self.smdRectPad(self.module,size_pad, pcbnew.wxPoint(( w/2)-oBorderWidth/2,0),str(1)))
 
         xPos = -w/2+oBorderWidth+clearance+iew
-        oFingerSize = pcbnew.wxSize(pt/2, h-pt-iew-2*clearance-pt)
-        iFingerSize = pcbnew.wxSize(iew,h-2*pt-2*clearance)
-        #horizontal receive electrode trace
-        self.module.Add(self.smdRectPad(self.module,pcbnew.wxSize(w-2*oBorderWidth-2*clearance,iew), pcbnew.wxPoint(0,h/2-pt-clearance-iew/2),str(2)))
+        oFingerSize = pcbnew.wxSize(oew/2, h-oew-iew-2*clearance-oew)
+        iFingerSize = pcbnew.wxSize(iew,h-2*oew-2*clearance)
+        #horizontal inner electrode trace
+        self.module.Add(self.smdRectPad(self.module,pcbnew.wxSize(w-2*oBorderWidth-2*clearance,iew), pcbnew.wxPoint(0,h/2-oew-clearance-iew/2),str(2)))
         for i in range(0,oFingerCount):
-            #re-fingers
+            #inner electrode fingers
             self.module.Add(self.smdRectPad(self.module,iFingerSize, pcbnew.wxPoint(xPos-iew/2 ,0),str(2)))
-            #de-fingers
-            self.module.Add(self.smdRectPad(self.module,oFingerSize, pcbnew.wxPoint(xPos+pt*0.75,-w/h-pt-iew/2+pt/2),str(1)))
-            xPos += pt*1.5+iew
+            #outer electrode fingers
+            self.module.Add(self.smdRectPad(self.module,oFingerSize, pcbnew.wxPoint(xPos+oew*0.75,-w/h-oew-iew/2+oew/2),str(1)))
+            xPos += oew*1.5+iew
 
-        #rightmost re-finger
+        #rightmost inner electrode finger
         self.module.Add(self.smdRectPad(self.module,iFingerSize, pcbnew.wxPoint(xPos-iew/2,0),str(2)))
 
         textSize = self.GetTextSize()

--- a/mutualcap_button_wizard.py
+++ b/mutualcap_button_wizard.py
@@ -46,6 +46,7 @@ class MutualcapButtonWizard(FootprintWizardBase.FootprintWizard):
         self.AddParam("Pads", "Width", self.uMM, 12)
         self.AddParam("Pads", "Height", self.uMM, 12)
         self.AddParam("Pads", "Inner electrode width", self.uMM, 0.1)
+        self.AddParam("Pads", "Draw line around button", self.uBool, True)
 
     @property
     def pads(self):
@@ -79,6 +80,7 @@ class MutualcapButtonWizard(FootprintWizardBase.FootprintWizard):
         w  = self.pads["Width"]
         h  = self.pads["Height"]
         iew = self.pads["Inner electrode width"]
+        drawBox = self.pads["Draw line around button"]
 
         oFingerCount = int((w-3*pt-iew)/(1.5*pt+iew))
         oBorderWidth = (w-pt-iew-oFingerCount*(1.5*pt+iew))/2
@@ -112,5 +114,9 @@ class MutualcapButtonWizard(FootprintWizardBase.FootprintWizard):
         textSize = self.GetTextSize()
         self.draw.Value(0, h/2+textSize, textSize)
         self.draw.Reference(0, -h/2-textSize, textSize)
+
+        #optionally draw silkscreen line around button
+        if(drawBox):
+            self.draw.Box(0,0,w,h)
 
 MutualcapButtonWizard().register()


### PR DESCRIPTION
added Mutual capacitance Capacitive Touch Button.
Measurements are taken from [QTAN0079](http://ww1.microchip.com/downloads/en/appnotes/doc10752.pdf), Page 37.

------------

Thanks for creating a pull request to contribute to the KiCad footprint wizards! To speed up integration of your PR, please check the following items:

- [x] Provide a description for your PR (are you creating a new wizard or improving an existing one?)
- [x] Include a screenshot of the wizard screen with an example created footprint

![Screenshot_748](https://user-images.githubusercontent.com/50383630/66079295-0f700280-e564-11e9-86a4-af6b69885a7a.png)
