### PR TITLE
BGA Wizard: Fix PadGridArray super call

### DIFF
--- a/PadArray.py
+++ b/PadArray.py
@@ -212,7 +212,7 @@ class PadGridArray(PadArray):
         @param py: pitch in y-direction
         @param centre: array centre point
         """
-        super(PadGridArray, self).__init__(pad)
+        super().__init__(pad)
 
         self.nx = int(nx)
         self.ny = int(ny)


### PR DESCRIPTION
Hey friends!

I was trying to use the BGA wizard today, and received this python error message:

![Screenshot from 2020-07-03 14-50-18](https://user-images.githubusercontent.com/44368/86495038-46ff1b80-bd3d-11ea-8899-cb04b1bf309e.png)

```
TypeError: super(type, obj): obj must be an instance or subtype or type
```

I was able to fix this and get the wizard to load with the included patch.

KiCad version: 5.1.6-c6e7f7d~86~ubuntu20.04.1 release build
Python version: Python 2.7.18rc1
OS: Ubuntu 20.04

Thanks!

------------

Thanks for creating a pull request to contribute to the KiCad footprint wizards! To speed up integration of your PR, please check the following items:

- [ ] Provide a description for your PR (are you creating a new wizard or improving an existing one?)
- [ ] Include a screenshot of the wizard screen with an example created footprint